### PR TITLE
Remove support for whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ docker run \
     --env "BIGCHAINDB_BACKEND_PORT=<port where BigchainDB is listening for connections>" \
     --env "BIGCHAINDB_WS_BACKEND_PORT=<port where BigchainDB is listening for websocket connections>" \
     --env "BIGCHAINDB_WS_FRONTEND_PORT=<port where nginx listens for BigchainDB WebSocket connections>" \
-    --env "MONGODB_WHITELIST=<a ':' separated list of IPs that can connect to MongoDB>" \
     --env "DNS_SERVER=<ip of the dns server>" \
     --name=nginx_3scale \
     --publish=<port where nginx listens for MongoDB connections as specified above>:<correcponding host port> \

--- a/docker_build_and_push.bash
+++ b/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/nginx_3scale:1.5 .
+docker build -t bigchaindb/nginx_3scale:1.6 .
 
-docker push bigchaindb/nginx_3scale:1.5
+docker push bigchaindb/nginx_3scale:1.6

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -270,11 +270,6 @@ http {
 #    preread_timeout 30s;
 #    tcp_nodelay on;
 #    
-#    # whitelist
-#    MONGODB_WHITELIST
-#    # deny access to everyone else
-#    deny all;
-#    
 #    # allow 16 connections from the same IP address
 #    limit_conn two 16;
 #    

--- a/nginx_entrypoint.bash
+++ b/nginx_entrypoint.bash
@@ -8,7 +8,6 @@ mongodb_backend_port=`printenv MONGODB_BACKEND_PORT`
 bdb_frontend_port=`printenv BIGCHAINDB_FRONTEND_PORT`
 bdb_backend_host=`printenv BIGCHAINDB_BACKEND_HOST`
 bdb_backend_port=`printenv BIGCHAINDB_BACKEND_PORT`
-mongodb_whitelist=`printenv MONGODB_WHITELIST`
 dns_server=`printenv DNS_SERVER`
 nginx_health_check_port=`printenv NGINX_HEALTH_CHECK_PORT`
 
@@ -65,15 +64,6 @@ sed -i "s|PROVIDER_KEY|${threescale_provider_key}|g" $NGINX_CONF_FILE
 sed -i "s|THREESCALE_VERSION_HEADER|${threescale_version_header}|g" $NGINX_CONF_FILE
 sed -i "s|HEALTH_CHECK_PORT|${nginx_health_check_port}|g" $NGINX_CONF_FILE
 sed -i "s|THREESCALE_RESPONSE_SECRET_TOKEN|${threescale_secret_token}|g" $NGINX_CONF_FILE
-
-# populate the whitelist in the conf file as per MONGODB_WHITELIST env var
-hosts=$(echo ${mongodb_whitelist} | tr ":" "\n")
-for host in $hosts; do
-  sed -i "s|MONGODB_WHITELIST|allow ${host};\n    MONGODB_WHITELIST|g" $NGINX_CONF_FILE
-done
-
-# remove the MONGODB_WHITELIST marker string from template
-sed -i "s|MONGODB_WHITELIST||g" $NGINX_CONF_FILE
 
 # start nginx
 echo "INFO: starting nginx..."


### PR DESCRIPTION
Remove support for whitelist MongoDB hosts, now that we have TLS support.