### PR TITLE
Use service_token instead of provider_key

### DIFF
--- a/docker_build_and_push.bash
+++ b/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/nginx_3scale:2.0 .
+docker build -t bigchaindb/nginx_3scale:3.0 .
 
-docker push bigchaindb/nginx_3scale:2.0
+docker push bigchaindb/nginx_3scale:3.0

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -61,7 +61,7 @@ http {
     location = /out_of_band_authrep_action {
       internal;
       proxy_pass_request_headers off;
-      set $provider_key "PROVIDER_KEY";
+      set $service_token "SERVICE_TOKEN";
       content_by_lua "require('nginx').post_action_content()";
     }
 
@@ -70,8 +70,8 @@ http {
     # exceeded the limits in his application plan.
     location = /threescale_auth {
       internal;
-      set $provider_key "PROVIDER_KEY";
-      proxy_pass $threescale_backend/transactions/authorize.xml?provider_key=$provider_key&service_id=$service_id&$usage&$credentials&log%5Bcode%5D=$arg_code&log%5Brequest%5D=$arg_req&log%5Bresponse%5D=$arg_resp;
+      set $service_token "SERVICE_TOKEN";
+      proxy_pass $threescale_backend/transactions/authorize.xml?service_token=$service_token&service_id=$service_id&$usage&$credentials&log%5Bcode%5D=$arg_code&log%5Brequest%5D=$arg_req&log%5Bresponse%5D=$arg_resp;
       proxy_set_header  Host  "su1.3scale.net";
       #proxy_set_header  Host  "echo-api.3scale.net";
       proxy_set_header  X-3scale-User-Agent "nginx$deployment";
@@ -82,7 +82,7 @@ http {
     # in the 3scale backend.
     location = /threescale_report {
       internal;
-      set $provider_key "PROVIDER_KEY";
+      set $service_token "SERVICE_TOKEN";
       proxy_pass $threescale_backend/transactions.xml;
       proxy_set_header  Host  "su1.3scale.net";
       #proxy_set_header  Host  "echo-api.3scale.net";
@@ -111,7 +111,7 @@ http {
       #}
 
       if ($request_method = POST ) {
-        set $provider_key null;
+        set $service_token null;
         set $cached_key null;
         set $credentials null;
         set $usage null;

--- a/nginx.lua.template
+++ b/nginx.lua.template
@@ -216,7 +216,7 @@ end
 
 function get_debug_value()
   local h = ngx.req.get_headers()
-  if h["X-3scale-debug"] == 'PROVIDER_KEY' then
+  if h["X-3scale-debug"] == 'SERVICE_TOKEN' then
     return true
   else
     return false
@@ -387,7 +387,7 @@ function _M.post_action_content()
   -- form the payload to report to 3scale
   local report = {}
   report['service_id'] = ngx.var.service_id
-  report['provider_key'] = ngx.var.provider_key
+  report['service_token'] = ngx.var.service_token
   report['transactions[0][app_id]'] = app_id
   report['transactions[0][usage][post_transactions]'] = report_data['post_transactions']
   report['transactions[0][usage][request_body_size]'] = report_data['request_body_size']

--- a/nginx_entrypoint.bash
+++ b/nginx_entrypoint.bash
@@ -18,7 +18,7 @@ THREESCALE_CREDENTIALS_DIR=/usr/local/openresty/nginx/conf/threescale
 threescale_secret_token=`cat ${THREESCALE_CREDENTIALS_DIR}/secret-token`
 threescale_service_id=`cat ${THREESCALE_CREDENTIALS_DIR}/service-id`
 threescale_version_header=`cat ${THREESCALE_CREDENTIALS_DIR}/version-header`
-threescale_provider_key=`cat ${THREESCALE_CREDENTIALS_DIR}/provider-key`
+threescale_service_token=`cat ${THREESCALE_CREDENTIALS_DIR}/service-token`
 
 
 # sanity checks TODO(Krish): hardening
@@ -29,7 +29,7 @@ if [[ -z "${dns_server}" || \
     -z "${threescale_secret_token}" || \
     -z "${threescale_service_id}" || \
     -z "${threescale_version_header}" || \
-    -z "${threescale_provider_key}" ]]; then
+    -z "${threescale_service_token}" ]]; then
   echo "Invalid environment settings detected. Exiting!"
   exit 1
 fi
@@ -40,7 +40,7 @@ NGINX_CONF_FILE=/usr/local/openresty/nginx/conf/nginx.conf
 # configure the nginx.lua file with env variables
 sed -i "s|SERVICE_ID|${threescale_service_id}|g" ${NGINX_LUA_FILE}
 sed -i "s|THREESCALE_RESPONSE_SECRET_TOKEN|${threescale_secret_token}|g" ${NGINX_LUA_FILE}
-sed -i "s|PROVIDER_KEY|${threescale_provider_key}|g" ${NGINX_LUA_FILE}
+sed -i "s|SERVICE_TOKEN|${threescale_service_token}|g" ${NGINX_LUA_FILE}
 
 # configure the nginx.conf file with env variables
 sed -i "s|DNS_SERVER|${dns_server}|g" ${NGINX_CONF_FILE}
@@ -50,7 +50,7 @@ sed -i "s|BIGCHAINDB_API_PORT|${bdb_api_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|THREESCALE_RESPONSE_SECRET_TOKEN|${threescale_secret_token}|g" $NGINX_CONF_FILE
 sed -i "s|SERVICE_ID|${threescale_service_id}|g" $NGINX_CONF_FILE
 sed -i "s|THREESCALE_VERSION_HEADER|${threescale_version_header}|g" $NGINX_CONF_FILE
-sed -i "s|PROVIDER_KEY|${threescale_provider_key}|g" $NGINX_CONF_FILE
+sed -i "s|SERVICE_TOKEN|${threescale_service_token}|g" $NGINX_CONF_FILE
 
 
 # start nginx


### PR DESCRIPTION
Use the 3scale service token instead of provider key, till we have a better way for key rotation.

Note: The corresponding documentation changes will be done when the appropriate k8s deployment changes are made.
